### PR TITLE
Add integration tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: ruby
+rvm:
+  - 2.1
+
+before_install:
+  - export NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+
+install:
+  - bundle install
+
+script:
+  - bundle exec jekyll build --drafts
+  - bundle exec htmlproof ./_site
+
+notifications:
+  email: false
+
+branches:
+  only:
+    - gh-pages

--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,7 @@ gem 'maruku',     '=0.6.1'
 gem 'rdiscount',  '=1.6.8'
 gem 'RedCloth',   '=4.2.9'
 gem 'kramdown',   '=1.0.2'
+
+group :test do
+  gem 'html-proofer'
+end

--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,7 @@ safe: true
 lsi: false
 baseurl:
 url: engineering.lonelyplanet.com
+exclude: [vendor]
 authors:
   mriddle:
     display_name: Matt Riddle


### PR DESCRIPTION
This adds a continuous testing with [Proofer](https://github.com/gjtorikian/html-proofer). 

> Proofer is a set of tests to validate your HTML output. These tests check if your image references are legitimate, if they have alt tags, if your internal links are working, and so on.

You must [enable Travis](http://docs.travis-ci.com/user/getting-started/) to see it working.
